### PR TITLE
Extra tokenId in a different manner

### DIFF
--- a/src/helpers/offersHelperFunctions.js
+++ b/src/helpers/offersHelperFunctions.js
@@ -23,12 +23,14 @@ function fetchOffers(dict) {
     const floorPrice = _extractFloorPrice(card);
     const tokenName = _extractTokenName(card);
     const tokenId = _extractTokenId(card);
+    const offerUrl = _extractOfferUrl(card);
     if (floorPrice && tokenName) {
       const uniqIdentifier = `${tokenName}_${tokenId || "unknownTokenId"}`;
       dict[uniqIdentifier] = {
         floorPrice: floorPrice,
         tokenId: tokenId,
         tokenName: tokenName,
+        offerUrl: offerUrl,
       }
     }
   });
@@ -45,6 +47,14 @@ function _extractTokenId(card) {
     const href = card.getAttribute("href") || "";
     const tokenId = href.split("/").slice(-1).pop();
     return tokenId === "" ? undefined : Number(tokenId); // catch case where tokenId is empty string
+  } catch(err) {
+    return undefined;
+  }
+}
+function _extractOfferUrl(card) {
+  try {
+    const href = card.getAttribute("href");
+    return href ? `https://opensea.io${href}` : undefined;
   } catch(err) {
     return undefined;
   }


### PR DESCRIPTION
Instead of getting it from the name, get from the `href` element of the card.

In case of the [The Sandbox](https://opensea.io/collection/sandbox?search[sortAscending]=true&search[sortBy]=PRICE&search[stringTraits][0][name]=Type&search[stringTraits][0][values][0]=Land&search[toggles][0]=BUY_NOW) example, the `tokenId` was not present in the card in the same way as in for the [Coolcats](https://opensea.io/collection/cool-cats-nft?search[sortAscending]=true&search[sortBy]=PRICE&search[toggles][0]=BUY_NOW) one.