### PR TITLE
Small updates, see comments below

### DIFF
--- a/src/functions/offers.js
+++ b/src/functions/offers.js
@@ -159,6 +159,14 @@ function _extractOffers(__wired__) {
 
 function _sortOffersLowToHigh(offers, currencyDict) {
   return offers.sort((a,b) => {
+    if (!a.floorPrice) {
+      return 1
+    }
+
+    if (!b.floorPrice) {
+      return -1;
+    }
+
     const getUsdValue = (offer, currencyDict) => {
       const currencySymbol = offer.floorPrice.currency;
       const targetCurrency = Object.values(currencyDict).find(o => o.symbol === currencySymbol);

--- a/src/functions/offers.js
+++ b/src/functions/offers.js
@@ -145,6 +145,7 @@ function _extractOffers(__wired__) {
       return {
         name: o.name,
         tokenId: tokenId,
+        displayImageUrl: o.displayImageUrl,
         assetContract: assetContract,
         offerUrl: contractAndTokenIdExist ? `https://opensea.io/assets/${assetContract}/${tokenId}` : undefined,
       };

--- a/src/functions/offers.js
+++ b/src/functions/offers.js
@@ -46,7 +46,7 @@ const offersByUrl = async (url, optionsGiven = {}) => {
     browserInstance: undefined,
   };
   const options = { ...optionsDefault, ...optionsGiven };
-  const { debug, logs, browserInstance } = options;
+  const { debug, logs, browserInstance, sort } = options;
   const customPuppeteerProvided = Boolean(optionsGiven.puppeteerInstace);
   logs && console.log(`=== scraping started ===\nScraping Opensea URL: ${url}`);
   logs && console.log(`\n=== options ===\ndebug          : ${debug}\nlogs           : ${logs}\nbrowserInstance: ${browserInstance ? "provided by user" : "default"}`);
@@ -82,7 +82,7 @@ const offersByUrl = async (url, optionsGiven = {}) => {
 
   logs && console.log("extracting offers and stats from __wired__ variable");
   return {
-    offers: _extractOffers(__wired__),
+    offers: _extractOffers(__wired__, { sort }),
     stats: _extractStats(__wired__),
   };
 }
@@ -101,7 +101,7 @@ function _extractStats(__wired__) {
     return "stats not availible. Report issue if you think this is a bug: https://github.com/dcts/opensea-scraper/issues/new";
   }
 }
-function _extractOffers(__wired__) {
+function _extractOffers(__wired__, { sort = true } = {}) {
   // create currency dict to extract different offer currencies
   const currencyDict = {};
   Object.values(__wired__.records)
@@ -155,7 +155,8 @@ function _extractOffers(__wired__) {
   floorPrices.forEach((floorPrice, indx) => {
     offers[indx].floorPrice = floorPrice;
   });
-  return _sortOffersLowToHigh(offers, currencyDict);
+
+  return sort ? _sortOffersLowToHigh(offers, currencyDict) : offers;
 }
 
 function _sortOffersLowToHigh(offers, currencyDict) {


### PR DESCRIPTION
Take this [url](https://opensea.io/collection/boredapeyachtclub?search[sortAscending]=true&search[sortBy]=PRICE&search[stringTraits][0][name]=Background&search[stringTraits][0][values][0]=Purple&search[stringTraits][1][name]=Earring&search[stringTraits][1][values][0]=Silver%20Hoop&search[stringTraits][2][name]=Eyes&search[stringTraits][2][values][0]=Bloodshot) for example. 

You could see, that not all NFTs are listed and that breaks the function. This would fix it.

A workaround is to supply a URL with the `buy_now` filter enabled, like in this [url](https://opensea.io/collection/boredapeyachtclub?search[sortAscending]=true&search[sortBy]=PRICE&search[stringTraits][0][name]=Background&search[stringTraits][0][values][0]=Purple&search[stringTraits][1][name]=Earring&search[stringTraits][1][values][0]=Silver%20Hoop&search[stringTraits][2][name]=Eyes&search[stringTraits][2][values][0]=Bloodshot).