### PR TITLE
fix definitions for rankings function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,8 +29,8 @@ declare module "opensea-scraper" {
   export function basicInfo(slug: string): Promise<Record<string, any>>;
   export function rankings(
     type?: string,
-    chain?: string,
     options?: IOptions,
+    chain?: string,
   ): Promise<IRanking[]>;
   export function offers(
     slug: string,


### PR DESCRIPTION
Parameters of ranking functions were swapped in the declaration when compared to the implementation. This causes invalid data when using with typescript, because the chain is passed in as options and no warnings are raised.